### PR TITLE
prepare northwind db for bug example: when group by Employee, expand …

### DIFF
--- a/datagrid-webapi/datagrid-webapi/Controllers/OrdersController.cs
+++ b/datagrid-webapi/datagrid-webapi/Controllers/OrdersController.cs
@@ -18,6 +18,14 @@ namespace datagrid_webapi.Controllers
         [HttpGet]
         public HttpResponseMessage Get(DataSourceLoadOptions loadOptions)
         {
+            //  used for create case for show error in DataSourceLoader.Load which leads to break work of DxGrid
+            if (_db.Orders.All(q => q.EmployeeID != null))
+            {
+                var someOrders = _db.Orders.Take(10).ToList();
+                someOrders.ForEach(q => q.EmployeeID = null);
+                _db.SaveChanges();
+            }
+
             loadOptions.PrimaryKey = new[] { "OrderID" };
 
             var orders = from o in _db.Orders
@@ -27,7 +35,8 @@ namespace datagrid_webapi.Controllers
                              o.CustomerID,
                              CustomerName = o.Customer.ContactName,
                              o.EmployeeID,
-                             EmployeeName = o.Employee.FirstName + " " + o.Employee.LastName,
+                             // need for reproduce case when group item key is null
+                             EmployeeName = o.Employee != null ? o.Employee.FirstName + " " + o.Employee.LastName : null,
                              o.OrderDate,
                              o.RequiredDate,
                              o.ShippedDate,
@@ -63,7 +72,7 @@ namespace datagrid_webapi.Controllers
 
             return Request.CreateResponse(HttpStatusCode.OK);
         }
-        
+
         [HttpPost]
         public HttpResponseMessage Post(FormDataCollection form)
         {
@@ -81,7 +90,7 @@ namespace datagrid_webapi.Controllers
 
             return Request.CreateResponse(HttpStatusCode.OK);
         }
-        
+
         [HttpDelete]
         public HttpResponseMessage Delete(FormDataCollection form)
         {

--- a/datagrid-webapi/datagrid-webapi/datagrid-webapi.csproj
+++ b/datagrid-webapi/datagrid-webapi/datagrid-webapi.csproj
@@ -24,6 +24,7 @@
     <UseGlobalApplicationHostFile />
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <Use64BitIISExpress />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -43,9 +44,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="DevExtreme.AspNet.Data, Version=1.2.0.0, Culture=neutral, PublicKeyToken=982f5dab1439d0f7, processorArchitecture=MSIL">
-      <HintPath>..\packages\DevExtreme.AspNet.Data.1.2.0\lib\net40\DevExtreme.AspNet.Data.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="DevExtreme.AspNet.Data, Version=1.4.0.0, Culture=neutral, PublicKeyToken=982f5dab1439d0f7, processorArchitecture=MSIL">
+      <HintPath>..\packages\DevExtreme.AspNet.Data.1.4.0\lib\net40\DevExtreme.AspNet.Data.dll</HintPath>
     </Reference>
     <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
       <HintPath>..\packages\EntityFramework.6.1.3\lib\net45\EntityFramework.dll</HintPath>
@@ -177,7 +177,7 @@
     <VisualStudio>
       <FlavorProperties GUID="{349c5851-65df-11da-9384-00065b846f21}">
         <WebProjectProperties>
-          <UseIIS>True</UseIIS>
+          <UseIIS>False</UseIIS>
           <AutoAssignPort>True</AutoAssignPort>
           <DevelopmentServerPort>63429</DevelopmentServerPort>
           <DevelopmentServerVPath>/</DevelopmentServerVPath>

--- a/datagrid-webapi/datagrid-webapi/packages.config
+++ b/datagrid-webapi/datagrid-webapi/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DevExtreme.AspNet.Data" version="1.2.0" targetFramework="net452" />
+  <package id="DevExtreme.AspNet.Data" version="1.4.0" targetFramework="net452" />
   <package id="EntityFramework" version="6.1.3" targetFramework="net452" />
   <package id="Microsoft.ApplicationInsights" version="2.1.0" targetFramework="net452" />
   <package id="Microsoft.ApplicationInsights.Agent.Intercept" version="1.2.1" targetFramework="net452" />


### PR DESCRIPTION
…some of group items which have more elements than in 1 page, then (breaking table) order by some field...and we get bug. In details: after analizing correct and bad work of grid -> bug placed in processing  of 2nd request after ordering, where grid try to find count of groups before expanded one.Soo, when one of this groups is null it return incorrect groupCount ( -1 from correct value)

![err](https://user-images.githubusercontent.com/2745401/37510598-b9578fd6-290c-11e8-8809-2dffa4c2b239.png)
