### PR TITLE
Update DevExtreme resources in ASP.NET demos

### DIFF
--- a/datagrid-mvc5/datagrid-mvc5/bower.json
+++ b/datagrid-mvc5/datagrid-mvc5/bower.json
@@ -3,7 +3,7 @@
   "private": true,
   "dependencies": {
     "jquery": "^3.0.0",
-    "devextreme": "~17.2.3",
+    "devextreme": "~18.1.3",
     "devextreme-aspnet-data": "^1.2.0"
   }
 }

--- a/datagrid-mvc5/datagrid-mvc5/datagrid-mvc5.csproj
+++ b/datagrid-mvc5/datagrid-mvc5/datagrid-mvc5.csproj
@@ -44,8 +44,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="DevExtreme.AspNet.Data, Version=1.2.7.0, Culture=neutral, PublicKeyToken=982f5dab1439d0f7, processorArchitecture=MSIL">
-      <HintPath>..\packages\DevExtreme.AspNet.Data.1.2.7\lib\net40\DevExtreme.AspNet.Data.dll</HintPath>
+    <Reference Include="DevExtreme.AspNet.Data, Version=1.4.5.0, Culture=neutral, PublicKeyToken=982f5dab1439d0f7, processorArchitecture=MSIL">
+      <HintPath>..\packages\DevExtreme.AspNet.Data.1.4.5\lib\net40\DevExtreme.AspNet.Data.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">

--- a/datagrid-mvc5/datagrid-mvc5/packages.config
+++ b/datagrid-mvc5/datagrid-mvc5/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DevExtreme.AspNet.Data" version="1.2.7" targetFramework="net46" />
+  <package id="DevExtreme.AspNet.Data" version="1.4.5" targetFramework="net46" />
   <package id="EntityFramework" version="6.1.3" targetFramework="net46" />
   <package id="Microsoft.AspNet.Mvc" version="5.2.3" targetFramework="net46" />
   <package id="Microsoft.AspNet.Razor" version="3.2.3" targetFramework="net46" />

--- a/datagrid-webapi/datagrid-webapi/bower.json
+++ b/datagrid-webapi/datagrid-webapi/bower.json
@@ -3,7 +3,7 @@
   "private": true,
   "dependencies": {
     "jquery": "^3.0.0",
-    "devextreme": "~17.2.3",
+    "devextreme": "~18.1.3",
     "devextreme-aspnet-data": "^1.2.0"
   }
 }

--- a/datagrid-webapi/datagrid-webapi/datagrid-webapi.csproj
+++ b/datagrid-webapi/datagrid-webapi/datagrid-webapi.csproj
@@ -43,8 +43,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="DevExtreme.AspNet.Data, Version=1.2.0.0, Culture=neutral, PublicKeyToken=982f5dab1439d0f7, processorArchitecture=MSIL">
-      <HintPath>..\packages\DevExtreme.AspNet.Data.1.2.0\lib\net40\DevExtreme.AspNet.Data.dll</HintPath>
+    <Reference Include="DevExtreme.AspNet.Data, Version=1.4.5.0, Culture=neutral, PublicKeyToken=982f5dab1439d0f7, processorArchitecture=MSIL">
+      <HintPath>..\packages\DevExtreme.AspNet.Data.1.4.5\lib\net40\DevExtreme.AspNet.Data.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">

--- a/datagrid-webapi/datagrid-webapi/packages.config
+++ b/datagrid-webapi/datagrid-webapi/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DevExtreme.AspNet.Data" version="1.2.0" targetFramework="net452" />
+  <package id="DevExtreme.AspNet.Data" version="1.4.5" targetFramework="net452" />
   <package id="EntityFramework" version="6.1.3" targetFramework="net452" />
   <package id="Microsoft.ApplicationInsights" version="2.1.0" targetFramework="net452" />
   <package id="Microsoft.ApplicationInsights.Agent.Intercept" version="1.2.1" targetFramework="net452" />

--- a/pivotgrid-webapi/pivotgrid-webapi/bower.json
+++ b/pivotgrid-webapi/pivotgrid-webapi/bower.json
@@ -3,7 +3,7 @@
   "private": true,
   "dependencies": {
     "jquery": "^3.0.0",
-    "devextreme": "~17.2.3",
+    "devextreme": "~18.1.3",
     "devextreme-aspnet-data": "^1.2.0"
   }
 }

--- a/pivotgrid-webapi/pivotgrid-webapi/packages.config
+++ b/pivotgrid-webapi/pivotgrid-webapi/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DevExtreme.AspNet.Data" version="1.2.0" targetFramework="net452" />
+  <package id="DevExtreme.AspNet.Data" version="1.4.5" targetFramework="net452" />
   <package id="EntityFramework" version="6.1.3" targetFramework="net452" />
   <package id="Microsoft.ApplicationInsights" version="2.1.0" targetFramework="net452" />
   <package id="Microsoft.ApplicationInsights.Agent.Intercept" version="1.2.1" targetFramework="net452" />

--- a/pivotgrid-webapi/pivotgrid-webapi/pivotgrid-webapi.csproj
+++ b/pivotgrid-webapi/pivotgrid-webapi/pivotgrid-webapi.csproj
@@ -43,8 +43,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="DevExtreme.AspNet.Data, Version=1.2.0.0, Culture=neutral, PublicKeyToken=982f5dab1439d0f7, processorArchitecture=MSIL">
-      <HintPath>..\packages\DevExtreme.AspNet.Data.1.2.0\lib\net40\DevExtreme.AspNet.Data.dll</HintPath>
+    <Reference Include="DevExtreme.AspNet.Data, Version=1.4.5.0, Culture=neutral, PublicKeyToken=982f5dab1439d0f7, processorArchitecture=MSIL">
+      <HintPath>..\packages\DevExtreme.AspNet.Data.1.4.5\lib\net40\DevExtreme.AspNet.Data.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">


### PR DESCRIPTION
**Updates:**
- DevExtreme Bower package to ~18.1.3.
- DevExtreme.AspNet.Data NuGet package to 1.4.5.

**Note:**
It looks that we do not need to update DevExtreme.AspNet.Data Bower package - "^1.2.0" is specified for it.